### PR TITLE
Fix initial max mp for some classes

### DIFF
--- a/server/src/helpers/character/PlayerHelper.ts
+++ b/server/src/helpers/character/PlayerHelper.ts
@@ -88,7 +88,7 @@ export class PlayerHelper extends BaseService {
 
     player.baseClass = baseClass;
     player.mp.maximum = maxMP[baseClass];
-    player.stats.mp = 0;
+    player.stats.mp = maxMP[baseClass];
 
     const learnTrait: Record<BaseClass, string> = {
       [BaseClass.Healer]: 'Afflict',


### PR DESCRIPTION
All classes get set to a starting MP of 100, because when the mp stat is 0, it gets migrated to 100. This fixes it by setting the classes mp stat to the correct value.