### PR TITLE
Use mouse up for actions on map

### DIFF
--- a/client/src/app/containers/game-container/map/phaserstates/logic.ts
+++ b/client/src/app/containers/game-container/map/phaserstates/logic.ts
@@ -403,7 +403,7 @@ export class MapScene extends Phaser.Scene {
   private setupMapInteractions() {
     this.input.mouse.disableContextMenu();
 
-    this.input.on('pointerdown', (pointer) => {
+    this.input.on('pointerup', (pointer) => {
       if (this.input.activePointer.rightButtonDown() || !this.player) return;
 
       const xCoord = Math.floor(pointer.worldX / 64);


### PR DESCRIPTION
1. Fixes a bug with moving the map's window, and then clicking.
2. Feels more natural to let go of the mouse button, and move, then have it move while you are still holding the mouse button down.