### PR TITLE
Fix potion ounce description in shops

### DIFF
--- a/shared/functions/items.ts
+++ b/shared/functions/items.ts
@@ -82,7 +82,7 @@ export function descTextFor(player: IPlayer, item: ISimpleItem, itemDef: IItem, 
   }
 
   // how full it is, if at all
-  const ounces = item.mods.ounces || 0;
+  const ounces = item.mods.ounces ?? itemDef.ounces ?? 0;
   let fluidText = itemClass === ItemClass.Bottle && ounces > 0 ? `It is filled with ${ounces} oz of fluid. ` : '';
   if (itemClass === ItemClass.Bottle && ounces === 0) fluidText = 'It is empty.';
 


### PR DESCRIPTION
Items in shops don't have ounces set, so this falls back to the item definition if it's missing for the description.