### PR TITLE
Fix treasure not always showing up

### DIFF
--- a/client/src/app/containers/game-container/map/phaserstates/logic.ts
+++ b/client/src/app/containers/game-container/map/phaserstates/logic.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { difference, get, setWith, size } from 'lodash';
+import { difference, get, setWith } from 'lodash';
 import { Subscription } from 'rxjs';
 
 import { basePlayerSprite, basePlayerSwimmingSprite, FOVVisibility, ICharacter, IMapData, INPC,

--- a/client/src/app/containers/game-container/map/phaserstates/logic.ts
+++ b/client/src/app/containers/game-container/map/phaserstates/logic.ts
@@ -673,7 +673,9 @@ export class MapScene extends Phaser.Scene {
         const itemsXY = this.ground[x][y];
         if (!itemsXY) continue;
 
-        const numItemsHere = size(itemsXY);
+        // Get the number of items on the tile, by summing the amount of items in each array
+        const numItemsHere = Object.keys(itemsXY).map((type) => itemsXY[type].length).reduce((a, b) => a + b, 0);
+
         Object.keys(itemsXY).forEach(itemType => {
           if (itemsXY[itemType].length === 0 || (itemType === ItemClass.Coin && numItemsHere > 1)) {
             if (get(this.goldSprites, [x, y])) this.createTreasureSprite(x, y);


### PR DESCRIPTION
Sometimes itemsXY has empty arrays, which get counted as items, which causes creating the gold sprite to get skipped. So when you drop an item, you sometimes don't see the treasure. This fix adds up the length of each array.