### PR TITLE
Discord name fix nickname ->displayName->unknown

### DIFF
--- a/server/src/helpers/lobby/DiscordHelper.ts
+++ b/server/src/helpers/lobby/DiscordHelper.ts
@@ -178,7 +178,7 @@ export class DiscordHelper extends BaseService {
 
       if (channel.id === this.discordChannel.id) {
         let realName = this.game.lobbyManager.discordHash[author.id];
-        if (!realName) realName = member?.nickname ?? 'unknown';
+        if (!realName) realName = member?.nickname ?? member?.displayName ?? 'unknown';
 
         this.game.messageHelper.sendMessage(realName, cleanContent, true, !!this.game.lobbyManager.discordHash[author.id]);
       }


### PR DESCRIPTION
When someone doesn't have a nickname, it is currently showing as unknown, this tries to use the display name, before resorting to unknown.

Didn't set this up to test it, but it looks like it would work.