### PR TITLE
Fix count items macro &items

### DIFF
--- a/server/src/helpers/data/GroundManager.ts
+++ b/server/src/helpers/data/GroundManager.ts
@@ -243,7 +243,7 @@ export class GroundManager extends BaseService {
 
     return [itemStack];
   }
-  
+
   public getAllItemsFromGround(mapName: string): IGroundItem[] {
     const items: IGroundItem[] = [];
     Object.keys(this.ground[mapName] || {}).forEach(x => {

--- a/server/src/helpers/data/GroundManager.ts
+++ b/server/src/helpers/data/GroundManager.ts
@@ -243,6 +243,20 @@ export class GroundManager extends BaseService {
 
     return [itemStack];
   }
+  
+  public getAllItemsFromGround(mapName: string): IGroundItem[] {
+    let items: IGroundItem[] = []
+    Object.keys(this.ground[mapName] || {}).forEach(x => {
+      Object.keys(this.ground[mapName][x] || {}).forEach(y => {
+        Object.keys(this.ground[mapName][x][y] || {}).forEach(itemClass => {
+          (this.ground[mapName][x][y][itemClass] || []).forEach((item: IGroundItem) => {
+            items.push(item);
+          });
+        });
+      });
+    });
+    return items;
+  }
 
   public convertItemStackToList(item: IGroundItem, count = 1): ISimpleItem[] {
     return Array(count).fill(null).map(() => this.game.itemCreator.rerollItem(item.item));

--- a/server/src/helpers/data/GroundManager.ts
+++ b/server/src/helpers/data/GroundManager.ts
@@ -245,7 +245,7 @@ export class GroundManager extends BaseService {
   }
   
   public getAllItemsFromGround(mapName: string): IGroundItem[] {
-    let items: IGroundItem[] = []
+    const items: IGroundItem[] = [];
     Object.keys(this.ground[mapName] || {}).forEach(x => {
       Object.keys(this.ground[mapName][x] || {}).forEach(y => {
         Object.keys(this.ground[mapName][x][y] || {}).forEach(itemClass => {

--- a/server/src/helpers/game/commands/debug/countitems.ts
+++ b/server/src/helpers/game/commands/debug/countitems.ts
@@ -8,7 +8,8 @@ export class DebugCountItems extends MacroCommand {
   override canBeFast = false;
 
   override execute(player: IPlayer, args: IMacroCommandArgs) {
-    const message = `[Debug] There are currently ${this.game.groundManager.getAllItemsFromGround(player.map).length} items on the ground in this world.`;
+    const mapItemCount = this.game.groundManager.getAllItemsFromGround(player.map).length;
+    const message = `[Debug] There are currently ${mapItemCount} items on the ground in this world.`;
     this.game.messageHelper.sendLogMessageToPlayer(player, { message, sfx: undefined }, [MessageType.Description]);
   }
 }

--- a/server/src/helpers/game/commands/debug/countitems.ts
+++ b/server/src/helpers/game/commands/debug/countitems.ts
@@ -8,7 +8,7 @@ export class DebugCountItems extends MacroCommand {
   override canBeFast = false;
 
   override execute(player: IPlayer, args: IMacroCommandArgs) {
-    const message = `[Debug] There are currently ${this.game.groundManager.getItemsFromGround.length} items on the ground in this world.`;
+    const message = `[Debug] There are currently ${this.game.groundManager.getAllItemsFromGround(player.map).length} items on the ground in this world.`;
     this.game.messageHelper.sendLogMessageToPlayer(player, { message, sfx: undefined }, [MessageType.Description]);
   }
 }


### PR DESCRIPTION
Currently the countitems debug macro "&items" always returns 4. This change makes it tell the player the count of all the items on the players current map.