### PR TITLE
Enable debug port 7011 on server start:dev

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "setup": "npm i && npm run setup:content",
     "setup:content": "node scripts/setup",
     "start": "node dist/server/src/core/index",
-    "start:dev": "tsc-watch --sourceMap --onSuccess \"node -r source-map-support/register dist/server/src/core/index.js\"",
+    "start:dev": "tsc-watch --sourceMap --onSuccess \"node --inspect=7010 -r source-map-support/register dist/server/src/core/index.js\"",
     "lint": "eslint -c .eslintrc.json --ext .ts src",
     "build": "tsc",
     "postbuild": "madge --circular --warning dist/server/src/core/index.js"


### PR DESCRIPTION
Enabled debugging on port 7011 when you do npm run start:dev for the server