### PR TITLE
Add --unsafe-perm to client content building

### DIFF
--- a/client/scripts/prebuild-assets-all.js
+++ b/client/scripts/prebuild-assets-all.js
@@ -20,7 +20,7 @@ if(fs.existsSync('../../Content')) {
 
   dl('LandOfTheRair/Assets', 'src/assets', () => {
     dl('LandOfTheRair/Content', 'src/assets/content', () => {
-      childProcess.exec('cd src/assets/content && npm install', () => {
+      childProcess.exec('cd src/assets/content && npm install --unsafe-perm', () => {
       });
     });
   });


### PR DESCRIPTION
To match the dockerfile, and client, add unsafe-perm