### PR TITLE
Fix encruster

### DIFF
--- a/server/src/helpers/character/ItemHelper.ts
+++ b/server/src/helpers/character/ItemHelper.ts
@@ -141,27 +141,25 @@ export class ItemHelper extends BaseService {
     return true;
   }
 
-  public mergeItemRequirements(firstItemRequirements: IItemRequirements | undefined, secondItemRequirements: IItemRequirements)
-  {
-    if (!secondItemRequirements){
+  public mergeItemRequirements(firstItemRequirements: IItemRequirements | undefined, secondItemRequirements: IItemRequirements) {
+    if (!secondItemRequirements) {
       return firstItemRequirements;
     }
     if (!firstItemRequirements) {
       return secondItemRequirements;
     }
 
-    let requirements = firstItemRequirements;
-    if (secondItemRequirements?.alignment && !firstItemRequirements?.alignment){
+    const requirements = firstItemRequirements;
+    if (secondItemRequirements?.alignment && !firstItemRequirements?.alignment) {
       requirements.alignment = secondItemRequirements.alignment;
     }
-    if (secondItemRequirements?.baseClass && !firstItemRequirements.baseClass){
+    if (secondItemRequirements?.baseClass && !firstItemRequirements.baseClass) {
       requirements.baseClass = secondItemRequirements.baseClass;
     }
     if ((secondItemRequirements?.level ?? 1) > (firstItemRequirements?.level ?? 1)) {
       requirements.level = secondItemRequirements.level;
     }
-    if (secondItemRequirements?.quest && !firstItemRequirements.quest)
-    {
+    if (secondItemRequirements?.quest && !firstItemRequirements.quest) {
       requirements.quest = secondItemRequirements.quest;
     }
 

--- a/server/src/helpers/character/ItemHelper.ts
+++ b/server/src/helpers/character/ItemHelper.ts
@@ -141,6 +141,33 @@ export class ItemHelper extends BaseService {
     return true;
   }
 
+  public mergeItemRequirements(firstItemRequirements: IItemRequirements | undefined, secondItemRequirements: IItemRequirements)
+  {
+    if (!secondItemRequirements){
+      return firstItemRequirements;
+    }
+    if (!firstItemRequirements) {
+      return secondItemRequirements;
+    }
+
+    let requirements = firstItemRequirements;
+    if (secondItemRequirements?.alignment && !firstItemRequirements?.alignment){
+      requirements.alignment = secondItemRequirements.alignment;
+    }
+    if (secondItemRequirements?.baseClass && !firstItemRequirements.baseClass){
+      requirements.baseClass = secondItemRequirements.baseClass;
+    }
+    if ((secondItemRequirements?.level ?? 1) > (firstItemRequirements?.level ?? 1)) {
+      requirements.level = secondItemRequirements.level;
+    }
+    if (secondItemRequirements?.quest && !firstItemRequirements.quest)
+    {
+      requirements.quest = secondItemRequirements.quest;
+    }
+
+    return requirements;
+  }
+
   // check if an item is usable
   public reasonCantGetBenefitsFromItem(player: IPlayer, item: ISimpleItem): string {
     const requirements: IItemRequirements = this.game.itemHelper.getItemProperty(item, 'requirements');

--- a/server/src/models/world/ai/behaviors/encruster.ts
+++ b/server/src/models/world/ai/behaviors/encruster.ts
@@ -132,8 +132,8 @@ export class EncrusterBehavior implements IAIBehavior {
         if (!shouldPass) return 'You cannot encrust that gem into that item.';
 
         rightHand.mods.encrustItem = leftHand.name;
-        
-        game.itemHelper.setItemProperty(rightHand, 'requirements', 
+
+        game.itemHelper.setItemProperty(rightHand, 'requirements',
           game.itemHelper.mergeItemRequirements(leftRequirements, rightRequirements)
         );
 

--- a/server/src/models/world/ai/behaviors/encruster.ts
+++ b/server/src/models/world/ai/behaviors/encruster.ts
@@ -108,6 +108,8 @@ export class EncrusterBehavior implements IAIBehavior {
 
         if (!rightHand) return 'You do not have anything in your right hand!';
         if (!leftHand) return 'You do not have anything in your left hand!';
+        if (rightHand.mods.owner && rightHand.mods.owner !== player.username) return 'That item belongs to someone else!';
+        if (leftHand.mods.owner && leftHand.mods.owner !== player.username) return 'That gem belongs to someone else!';
 
         const itemClass = game.itemHelper.getItemProperty(rightHand, 'itemClass');
 
@@ -116,6 +118,7 @@ export class EncrusterBehavior implements IAIBehavior {
           encrustGive: leftEncrustGive,
           requirements: leftRequirements
         } = game.itemHelper.getItemProperties(leftHand, ['itemClass', 'encrustGive', 'requirements']);
+        const rightRequirements = game.itemHelper.getItemProperty(rightHand, 'requirements');
 
         if (leftItemClass !== ItemClass.Gem) return 'You are not holding a gem in your left hand!';
 
@@ -129,6 +132,12 @@ export class EncrusterBehavior implements IAIBehavior {
         if (!shouldPass) return 'You cannot encrust that gem into that item.';
 
         rightHand.mods.encrustItem = leftHand.name;
+        
+        game.itemHelper.setItemProperty(rightHand, 'requirements', 
+          game.itemHelper.mergeItemRequirements(leftRequirements, rightRequirements)
+        );
+
+        game.itemHelper.setItemProperty(rightHand, 'owner', player.username);
         game.characterHelper.setLeftHand(player, undefined);
 
         return 'Enjoy your new encrusted item!';


### PR DESCRIPTION
### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Can you post a screenshot of your changes (if applicable)?
First test: Encrust a level 20 gem onto a Thief-only sash. The sash should still be thief-only, and should require the gem's level 20 requirement.
![1 - sash before](https://user-images.githubusercontent.com/6930354/117340798-4e1c1c00-ae6f-11eb-87f6-e53ea4c872b1.PNG)
![2 - sash after](https://user-images.githubusercontent.com/6930354/117340805-4fe5df80-ae6f-11eb-8f8c-f1c785fdfc48.PNG)
![25 - sash still cannot be equipped](https://user-images.githubusercontent.com/6930354/117340815-5411fd00-ae6f-11eb-8117-b7d775104e69.PNG)

Second test: Unbound leather strength ring encrusted with a vamp heart. New ring should be tied and require level 10 to use.
![3 - str ring before](https://user-images.githubusercontent.com/6930354/117341603-588ae580-ae70-11eb-9b80-5edb93a66c74.PNG)
![4 - ring after](https://user-images.githubusercontent.com/6930354/117341609-59bc1280-ae70-11eb-945f-5226ab70503f.PNG)


1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Encruster should tie items and merge the requirements of the gem into the base item