### PR TITLE
Fix upgrader

### DIFF
--- a/server/src/models/world/ai/behaviors/upgrader.ts
+++ b/server/src/models/world/ai/behaviors/upgrader.ts
@@ -44,8 +44,17 @@ export class UpgraderBehavior implements IAIBehavior {
         if (!game.itemHelper.isOwnedBy(player, leftHand)) return 'You do not own that material!';
         if (!game.itemHelper.canUpgradeItem(rightHand)) return 'I cannot upgrade that item for you!';
         if (!game.itemHelper.canUseItemForUpgrade(leftHand)) return 'That item cannot be used as an upgrade!';
-
+        
         game.itemHelper.upgradeItem(rightHand, leftHand.name, true);
+        
+        const leftRequirements = game.itemHelper.getItemProperty(leftHand, 'requirements');
+        const rightRequirements = game.itemHelper.getItemProperty(rightHand, 'requirements');
+
+        game.itemHelper.setItemProperty(rightHand, 'requirements',
+          game.itemHelper.mergeItemRequirements(leftRequirements, rightRequirements)
+        );
+        game.itemHelper.setItemProperty(rightHand, 'owner', player.username);
+        
         game.characterHelper.setLeftHand(player, undefined);
 
         return 'Your item is upgraded!';

--- a/server/src/models/world/ai/behaviors/upgrader.ts
+++ b/server/src/models/world/ai/behaviors/upgrader.ts
@@ -44,9 +44,9 @@ export class UpgraderBehavior implements IAIBehavior {
         if (!game.itemHelper.isOwnedBy(player, leftHand)) return 'You do not own that material!';
         if (!game.itemHelper.canUpgradeItem(rightHand)) return 'I cannot upgrade that item for you!';
         if (!game.itemHelper.canUseItemForUpgrade(leftHand)) return 'That item cannot be used as an upgrade!';
-        
+
         game.itemHelper.upgradeItem(rightHand, leftHand.name, true);
-        
+
         const leftRequirements = game.itemHelper.getItemProperty(leftHand, 'requirements');
         const rightRequirements = game.itemHelper.getItemProperty(rightHand, 'requirements');
 
@@ -54,7 +54,7 @@ export class UpgraderBehavior implements IAIBehavior {
           game.itemHelper.mergeItemRequirements(leftRequirements, rightRequirements)
         );
         game.itemHelper.setItemProperty(rightHand, 'owner', player.username);
-        
+
         game.characterHelper.setLeftHand(player, undefined);
 
         return 'Your item is upgraded!';


### PR DESCRIPTION
### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Can you post a screenshot of your changes (if applicable)?
I added a level 20 requirement to an enchanting brick to test merging requirements:
![1 - before robe](https://user-images.githubusercontent.com/6930354/117346548-e5846d80-ae75-11eb-8199-7b81d180ca75.PNG)
![2 - before brick](https://user-images.githubusercontent.com/6930354/117346555-e74e3100-ae75-11eb-8ef3-d0c4e6010d1e.PNG)
![3 - after upgrade](https://user-images.githubusercontent.com/6930354/117346561-e87f5e00-ae75-11eb-96fe-a64b98ef9044.PNG)
And verified that items are tying now, too:
![4 - tying proof too](https://user-images.githubusercontent.com/6930354/117346596-f208c600-ae75-11eb-9cfe-16575dd7cd6e.PNG)

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Copied the tying/merging functionality from Encruster over to Upgrader