### PR TITLE
Better crash message when behavior type is missing

### DIFF
--- a/server/src/helpers/data/NPCCreator.ts
+++ b/server/src/helpers/data/NPCCreator.ts
@@ -406,6 +406,9 @@ export class NPCCreator extends BaseService {
       behavior = cloneDeep(behavior);
 
       const initBehavior = behaviorTypes[behavior.type];
+      if (!initBehavior) {
+        throw new Error(`Could not find npc behavior type ${behavior.type}`);
+      }
       const behaviorInst: IAIBehavior = new initBehavior();
 
       if (behavior.props) {


### PR DESCRIPTION
When a behavior type is missing, crash with the name of the missing type.