### PR TITLE
Clear door cache when map loads.

### DIFF
--- a/client/src/app/containers/game-container/map/phaserstates/logic.ts
+++ b/client/src/app/containers/game-container/map/phaserstates/logic.ts
@@ -606,6 +606,7 @@ export class MapScene extends Phaser.Scene {
       this.visibleItemSprites = {};
       this.visibleItemUUIDHash = {};
       this.goldSprites = {};
+      this.doors = [];
     }
     const player = this.game.observables.player.getValue();
     this.player = player;


### PR DESCRIPTION
Clears door cache when map changes, so doors don't get shown on the wrong map.