### PR TITLE
Let zero skill = zero percent still return skill 1 recipes

### DIFF
--- a/client/src/app/containers/game-container/tradeskill/tradeskill.component.ts
+++ b/client/src/app/containers/game-container/tradeskill/tradeskill.component.ts
@@ -116,7 +116,7 @@ export class TradeskillComponent implements OnInit, OnDestroy {
   private updateRecipes() {
     if (!this.tradeskillInfo || !this.tradeskillInfo.tradeskill || !this.player) return;
 
-    if (this.getPlayerSkillXP() === this.skillPercent) return;
+    if (this.getPlayerSkillXP() === this.skillPercent && this.skillPercent > 0) return;
 
     const skill = this.getPlayerSkill();
 


### PR DESCRIPTION
### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Can you post a screenshot of your changes (if applicable)?
before:
![image](https://user-images.githubusercontent.com/6930354/120239293-f08bad00-c22b-11eb-9592-83224fb892b7.png)

after:
![image](https://user-images.githubusercontent.com/6930354/120239265-e1a4fa80-c22b-11eb-9a42-131d42281032.png)

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Players who have never crafted anything were getting empty tradeskill windows, this change prevents zero exp from shortcutting the recipe lookup